### PR TITLE
Support for controlParams in link properties

### DIFF
--- a/RNBranch/RNBranch.m
+++ b/RNBranch/RNBranch.m
@@ -135,6 +135,7 @@ RCT_EXPORT_METHOD(showShareSheet:(NSDictionary *)shareOptionsMap
     BranchLinkProperties *linkProperties = [[BranchLinkProperties alloc] init];
     linkProperties.channel = [linkPropertiesMap objectForKey:@"channel"];
     linkProperties.feature = [linkPropertiesMap objectForKey:@"feature"];
+    linkProperties.controlParams = [linkPropertiesMap objectForKey:@"controlParams"];
 
     [branchUniversalObject showShareSheetWithLinkProperties:linkProperties
                                              andShareText:[shareOptionsMap objectForKey:@"messageBody"]

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -189,6 +189,16 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
                    .setChannel(linkPropertiesMap.getString("channel"))
                    .setFeature(linkPropertiesMap.getString("feature"));
 
+        ReadableMap controlParams = linkPropertiesMap.getMap("controlParams");
+        ReadableMapKeySetIterator iterator = controlParams.keySetIterator();
+        while (iterator.hasNextKey()) {
+          String controlParamKey = iterator.nextKey();
+          Object controlParamObject = getReadableMapObjectForKey(controlParams, controlParamKey);
+          if (controlParamObject instanceof String) {
+            linkProperties.addControlParameter(controlParamKey, (String)controlParamObject);
+          }
+        }
+
         branchUniversalObject.showShareSheet(getCurrentActivity(),
                                           linkProperties,
                                           shareSheetStyle,


### PR DESCRIPTION
This PR allows you to pass `controlParams` (such as `$desktop_url` and `$ios_url`) along with your other link properties to the `showShareSheet` method like so: 

```javascript
  const linkProperties = {
    feature: 'share',
    channel: 'channel',
    controlParams: {
      '$desktop_url': myContent.desktopShareUrl
    }
  };

  branch.showShareSheet(shareOptions, branchUniversalObject, linkProperties, ({channel, completed, error}) => {});
```