### PR TITLE
Allow the share sheet to be shown from presented VC's

### DIFF
--- a/RNBranch/RNBranch.m
+++ b/RNBranch/RNBranch.m
@@ -173,10 +173,12 @@ RCT_EXPORT_METHOD(
   dispatch_async(dispatch_get_main_queue(), ^(void){
     BranchUniversalObject *branchUniversalObject = [self createBranchUniversalObject:branchUniversalObjectMap];
     BranchLinkProperties *linkProperties = [self createLinkProperties:linkProperties withControlParams:controlParamsMap];
-
+    
+    UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    UIViewController *fromViewController = (rootViewController.presentedViewController ? rootViewController.presentedViewController : rootViewController);
     [branchUniversalObject showShareSheetWithLinkProperties:linkProperties
                                              andShareText:[shareOptionsMap objectForKey:@"text"]
-                                             fromViewController:nil
+                                             fromViewController:fromViewController
                                               completion:^(NSString *activityType, BOOL completed){
       NSDictionary *result = @{
         @"channel" : activityType ? activityType : [NSNull null],


### PR DESCRIPTION
Allow the share sheet to be shown from a modally presented view controller. Could be changed to use a while loop if we wish to keep moving up the presentation hierarchy until we have the last one but this is a quick fix for many use cases.